### PR TITLE
Added more generic fuseki_endpoints.

### DIFF
--- a/vivo/README.md
+++ b/vivo/README.md
@@ -11,7 +11,7 @@ running.
 ## Variables
 
  - `VIVO_SOLR_HOSTNAME` Solr host name in docker-compose
- - `VIVO_CONTENT_TRIPLE_SOURCE` defaults to 'tdbContentTripleSource'.  To use Fueski, switch to sparqlContentTripleSource
- - `FUSEKI_HOSTNAME`
- - `FUSEKI_USERNAME`
- - `FUSEKI_PASSWORD`
+ - `VIVO_CONTENT_TRIPLE_SOURCE` defaults to 'tdbContentTripleSource'.  Will use
+   an external source if `FUSEKI_ENDPOINT` is set.
+ - `FUSEKI_ENDPOINT = http://admin:vivo@fuseki:3030/vivo/` If set will use an
+   external fuseki endpoint

--- a/vivo/applicationSetup.n3
+++ b/vivo/applicationSetup.n3
@@ -3,7 +3,7 @@
 # This file specifies the structure of the Vitro application: which modules
 # are used, and what parameters they require.
 #
-# Most Vitro installations will not need to modify this file. 
+# Most Vitro installations will not need to modify this file.
 #
 # For most installations, only the settings in the runtime.properties file will
 # be changed.
@@ -15,11 +15,11 @@
 
 # ----------------------------
 #
-# Describe the application by its implementing class and by references to the 
+# Describe the application by its implementing class and by references to the
 # modules it uses.
-# 
+#
 
-:application 
+:application
     a   vitroWebapp:application.ApplicationImpl ,
         vitroWebapp:modules.Application ;
     :hasSearchEngine              :instrumentedSearchEngineWrapper ;
@@ -32,7 +32,7 @@
 
 # ----------------------------
 #
-# Image processor module: 
+# Image processor module:
 #
 
 :iioImageProcessor
@@ -41,25 +41,25 @@
 
 # ----------------------------
 #
-# File storage module: 
+# File storage module:
 #    The PairTree-inspired implementation is the only standard option.
 #    It requires no parameters.
 #
 
-:ptiFileStorage 
+:ptiFileStorage
     a   vitroWebapp:filestorage.impl.FileStorageImplWrapper ,
         vitroWebapp:modules.fileStorage.FileStorage .
-               
+
 # ----------------------------
 #
-# Search engine module: 
+# Search engine module:
 #    The Solr-based implementation is the only standard option, but it can be
-#    wrapped in an "instrumented" wrapper, which provides additional logging 
+#    wrapped in an "instrumented" wrapper, which provides additional logging
 #    and more rigorous life-cycle checking.
 #
 
-:instrumentedSearchEngineWrapper 
-    a   vitroWebapp:searchengine.InstrumentedSearchEngineWrapper , 
+:instrumentedSearchEngineWrapper
+    a   vitroWebapp:searchengine.InstrumentedSearchEngineWrapper ,
         vitroWebapp:modules.searchEngine.SearchEngine ;
     :wraps :solrSearchEngine .
 
@@ -69,8 +69,8 @@
 
 # ----------------------------
 #
-# Search indexer module: 
-#    There is only one standard implementation. You must specify the number of 
+# Search indexer module:
+#    There is only one standard implementation. You must specify the number of
 #    worker threads in the thread pool.
 #
 
@@ -78,14 +78,14 @@
     a   vitroWebapp:searchindex.SearchIndexerImpl ,
         vitroWebapp:modules.searchIndexer.SearchIndexer ;
     :threadPoolSize "10" .
-    
+
 # ----------------------------
 #
 # Content triples source module: holds data contents
 #    The SDB-based implementation is the default option. It reads its parameters
 #    from the runtime.properties file, for backward compatibility.
 #
-#    Other implementations are based on a local TDB instance, a "standard" SPARQL 
+#    Other implementations are based on a local TDB instance, a "standard" SPARQL
 #    endpoint, or a Virtuoso endpoint, with parameters as shown.
 #
 
@@ -103,9 +103,9 @@
     a   vitroWebapp:triplesource.impl.sparql.ContentTripleSourceSPARQL ,
         vitroWebapp:modules.tripleSource.ContentTripleSource ;
 #    # The URI of the SPARQL endpoint for your triple-store.
-    :hasEndpointURI "http://{{FUSEKI_HOSTNAME}}:3030/vivo/query" ;
-#    # The URI to use for SPARQL UPDATE calls against your triple-store. 
-    :hasUpdateEndpointURI "http://{{FUSEKI_USERNAME}}:{{FUSEKI_PASSWORD}}@{{FUSEKI_HOSTNAME}}:3030/vivo/update" .
+    :hasEndpointURI "{{FUSEKI_QUERY}}" ;
+#    # The URI to use for SPARQL UPDATE calls against your triple-store.
+    :hasUpdateEndpointURI "{{FUSEKI_UPDATE}}" .
 
 #:virtuosoContentTripleSource
 #    a   vitroWebapp:triplesource.impl.virtuoso.ContentTripleSourceVirtuoso ,
@@ -127,10 +127,10 @@
 :tdbConfigurationTripleSource
     a   vitroWebapp:triplesource.impl.tdb.ConfigurationTripleSourceTDB ,
         vitroWebapp:modules.tripleSource.ConfigurationTripleSource .
-        
+
 # ----------------------------
 #
-# TBox reasoner module: 
+# TBox reasoner module:
 #    The JFact-based implementation is the only standard option.
 #    It requires no parameters.
 #

--- a/vivo/docker-entrypoint.sh
+++ b/vivo/docker-entrypoint.sh
@@ -1,29 +1,74 @@
 #! /bin/bash
 
-# Should be tdbContentTripleSource or sparqlContentTripleSource
-if [[ -z $VIVO_CONTENT_TRIPLE_SOURCE ]] ; then
-  export VIVO_CONTENT_TRIPLE_SOURCE="tdbContentTripleSource"
+# Parse FUSEKI_UPDATE if exists
+function parse_endpoint() {
+  pattern='^(([[:alnum:]]+)://)?(([[:alnum:]]+)(:([[:alnum:]]+))?@)?([^:^@]+)(:([[:digit:]]+))?/(.*)/.*$'
+  if [[ "${FUSEKI[endpoint]}" =~ $pattern ]]; then
+    FUSEKI[proto]=${BASH_REMATCH[2]}
+    FUSEKI[user]=${BASH_REMATCH[4]}
+    FUSEKI[password]=${BASH_REMATCH[6]}
+    FUSEKI[hostname]=${BASH_REMATCH[7]}
+    FUSEKI[port]=${BASH_REMATCH[9]}
+    if [[ -n ${FUSEKI[port]} ]]; then
+      FUSEKI[host]="${BASH_REMATCH[7]}:${BASH_REMATCH[9]}"
+    else
+      FUSEKI[host]=${FUSEKI[hostname]}
+    fi
+    FUSEKI[db]=${BASH_REMATCH[10]}
+  else
+    >&2 echo ${FUSEKI[url]} is url
+    FUSEKI[error]=1;
+  fi
+
+}
+
+# Defaults
+declare -A FUSEKI=([host]="fuseki:80"
+                   [proto]="http"
+                   [db]="vivo"
+                   [username]="admin"
+                   [password]="vivo"
+                  );
+
+: ${VIVO_CONTENT_TRIPLE_SOURCE:=tdbContentTripleSource}
+export VIVO_CONTENT_TRIPLE_SOURCE
+
+# If we have an update url, then get everything from that.
+if [[ -n ${FUSEKI_ENDPOINT} ]]; then
+  VIVO_CONTENT_TRIPLE_SOURCE=sparqlContentTripleSource
+  FUSEKI[endpoint]=${FUSEKI_ENDPOINT}
+  parse_endpoint
+
+  if [[ -n ${FUSEKI[error]} ]] ; then
+    >&2 echo "WARNING: ${FUSEKI[endpoint]} is not a valid endpoint";
+  fi
 fi
 
-content=$(cat runtime.properties.tpl)
-for var in $(compgen -e); do
-  content=$(echo "$content" | sed "s|{{$var}}|${!var}|g") 
-done
-echo "$content" > runtime.properties
+#declare -p FUSEKI
 
-content=$(cat applicationSetup.n3.tpl)
-for var in $(compgen -e); do
-  content=$(echo "$content" | sed "s|{{$var}}|${!var}|g") 
+# Fill these out even if not used.
+export FUSEKI_UPDATE="${FUSEKI[proto]}://${FUSEKI[username]}:${FUSEKI[password]}@${FUSEKI[host]}/${FUSEKI[db]}/update"
+export FUSEKI_QUERY="http://${FUSEKI[host]}/${FUSEKI[db]}/query"
+
+
+# Create if not there
+for f in runtime.properties applicationSetup.n3; do
+  if [[ ! -f $f ]]; then
+    content=$(cat $f.tpl)
+    for var in $(compgen -e); do
+      content=$(echo "$content" | sed "s|{{$var}}|${!var}|g")
+    done
+    echo "$content" > $f
+  fi
 done
-echo "$content" > applicationSetup.n3
 
 if [ -f "/usr/local/vivo/home/tdbModels/tdb.lock" ] ; then
   echo "WARNING: tdbModels lock file found.  removing."
   rm /usr/local/vivo/home/tdbModels/tdb.lock
-fi 
+fi
 if [ -f "/usr/local/vivo/home/tdbContentModels/tdb.lock" ] ; then
   echo "WARNING: tdbContentModels lock file found.  removing."
   rm /usr/local/vivo/home/tdbContentModels/tdb.lock
-fi 
+fi
 
 catalina.sh run


### PR DESCRIPTION
This pull request updates the configuatation so that you can set a single value ala 

```bash
FUSEKI_ENDPOINT=http://admin:quinnisgreat@fuseki:3030/covid19/
```
To connect to a FUSEKI database.  It is not required to be name `vivo`. 